### PR TITLE
Do not add the params.path to the last of cmd

### DIFF
--- a/denops/@ddu-sources/file_external.ts
+++ b/denops/@ddu-sources/file_external.ts
@@ -50,7 +50,7 @@ export class Source extends BaseSource<Params> {
         let numChunks = 0;
 
         const proc = Deno.run({
-          cmd: [...sourceParams.cmd, root],
+          cmd: sourceParams.cmd,
           stdout: "piped",
           stderr: "piped",
           cwd: root,


### PR DESCRIPTION
- It is done by being passed to cwd.
- A command user specified may not be accept a path.