### PR TITLE
Ignore AbortReason errors

### DIFF
--- a/denops/@ddu-sources/file_external.ts
+++ b/denops/@ddu-sources/file_external.ts
@@ -1,12 +1,12 @@
 import {
   type Item,
   type SourceOptions,
-} from "jsr:@shougo/ddu-vim@~6.1.0/types";
-import { BaseSource } from "jsr:@shougo/ddu-vim@~6.1.0/source";
+} from "jsr:@shougo/ddu-vim@~10.1.0/types";
+import { BaseSource } from "jsr:@shougo/ddu-vim@~10.1.0/source";
 import { type ActionData } from "jsr:@shougo/ddu-kind-file@~0.9.0";
 
 import type { Denops } from "jsr:@denops/core@~7.0.0";
-import * as fn from "jsr:@denops/std@~7.1.1/function";
+import * as fn from "jsr:@denops/std@~7.5.0/function";
 
 import { relative } from "jsr:@std/path@~1.0.3/relative";
 import { resolve } from "jsr:@std/path@~1.0.3/resolve";
@@ -47,7 +47,7 @@ async function tryGetStat(path: string): Promise<Deno.FileInfo | null> {
 }
 
 export class Source extends BaseSource<Params> {
-  kind = "file";
+  override kind = "file";
 
   gather(args: {
     denops: Denops;
@@ -133,8 +133,10 @@ export class Source extends BaseSource<Params> {
             controller.enqueue(items);
           }
         } catch (e: unknown) {
-          if (e instanceof DOMException) {
-            proc.kill("SIGTERM");
+          proc.kill("SIGTERM");
+
+          if (e instanceof Error && e.name.includes("AbortReason")) {
+            // Ignore AbortReason errors
           } else {
             console.error(e);
           }


### PR DESCRIPTION
If `ddu.vim` is aborted, the source prints the error.
It should be ignored.